### PR TITLE
fix(AntiWindupController): Introducing NaN prevention

### DIFF
--- a/antiwindupcontroller.go
+++ b/antiwindupcontroller.go
@@ -53,6 +53,8 @@ type AntiWindupControllerState struct {
 	ControlErrorDerivative float64
 	// ControlSignal is the current control signal output of the controller.
 	ControlSignal float64
+	// UnsaturatedControlSignal is the control signal before saturation.
+	UnsaturatedControlSignal float64
 }
 
 // AntiWindupControllerInput holds the input parameters to an AntiWindupController.
@@ -78,10 +80,10 @@ func (c *AntiWindupController) Update(input AntiWindupControllerInput) {
 	controlErrorIntegral := c.State.ControlErrorIntegrand*input.SamplingInterval.Seconds() + c.State.ControlErrorIntegral
 	controlErrorDerivative := ((1/c.Config.LowPassTimeConstant.Seconds())*(e-c.State.ControlError) +
 		c.State.ControlErrorDerivative) / (input.SamplingInterval.Seconds()/c.Config.LowPassTimeConstant.Seconds() + 1)
-	u := e*c.Config.ProportionalGain + c.Config.IntegralGain*controlErrorIntegral +
+	c.State.UnsaturatedControlSignal = e*c.Config.ProportionalGain + c.Config.IntegralGain*controlErrorIntegral +
 		c.Config.DerivativeGain*controlErrorDerivative + input.FeedForwardSignal
-	c.State.ControlSignal = math.Max(c.Config.MinOutput, math.Min(c.Config.MaxOutput, u))
-	c.State.ControlErrorIntegrand = e + c.Config.AntiWindUpGain*(c.State.ControlSignal-u)
+	c.State.ControlSignal = math.Max(c.Config.MinOutput, math.Min(c.Config.MaxOutput, c.State.UnsaturatedControlSignal))
+	c.State.ControlErrorIntegrand = e + c.Config.AntiWindUpGain*(c.State.ControlSignal-c.State.UnsaturatedControlSignal)
 	c.State.ControlErrorIntegrand = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, c.State.ControlErrorIntegrand))
 	c.State.ControlErrorIntegral = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorIntegral))
 	c.State.ControlErrorDerivative = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorDerivative))

--- a/trackingcontroller.go
+++ b/trackingcontroller.go
@@ -12,6 +12,9 @@ import (
 // Chapter 6 of Åström and Murray, Feedback Systems:
 // An Introduction to Scientists and Engineers, 2008
 // (http://www.cds.caltech.edu/~murray/amwiki)
+//
+// The ControlError, ControlErrorIntegrand, ControlErrorIntegral and ControlErrorDerivative are prevented
+// from reaching +/- inf by clamping them to [-math.MaxFloat64, math.MaxFloat64].
 type TrackingController struct {
 	// Config for the TrackingController.
 	Config TrackingControllerConfig
@@ -86,9 +89,10 @@ func (c *TrackingController) Update(input TrackingControllerInput) {
 	c.State.ControlSignal = math.Max(c.Config.MinOutput, math.Min(c.Config.MaxOutput, c.State.UnsaturatedControlSignal))
 	c.State.ControlErrorIntegrand = e + c.Config.AntiWindUpGain*(input.AppliedControlSignal-
 		c.State.UnsaturatedControlSignal)
-	c.State.ControlErrorIntegral = controlErrorIntegral
-	c.State.ControlErrorDerivative = controlErrorDerivative
-	c.State.ControlError = e
+	c.State.ControlErrorIntegrand = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, c.State.ControlErrorIntegrand))
+	c.State.ControlErrorIntegral = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorIntegral))
+	c.State.ControlErrorDerivative = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorDerivative))
+	c.State.ControlError = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, e))
 }
 
 // DischargeIntegral provides the ability to discharge the controller integral state

--- a/trackingcontroller.go
+++ b/trackingcontroller.go
@@ -81,10 +81,9 @@ func (c *TrackingController) Update(input TrackingControllerInput) {
 	controlErrorIntegral := c.State.ControlErrorIntegrand*input.SamplingInterval.Seconds() + c.State.ControlErrorIntegral
 	controlErrorDerivative := ((1/c.Config.LowPassTimeConstant.Seconds())*(e-c.State.ControlError) +
 		c.State.ControlErrorDerivative) / (input.SamplingInterval.Seconds()/c.Config.LowPassTimeConstant.Seconds() + 1)
-	u := e*c.Config.ProportionalGain + c.Config.IntegralGain*controlErrorIntegral +
+	c.State.UnsaturatedControlSignal = e*c.Config.ProportionalGain + c.Config.IntegralGain*controlErrorIntegral +
 		c.Config.DerivativeGain*controlErrorDerivative + input.FeedForwardSignal
-	c.State.UnsaturatedControlSignal = u
-	c.State.ControlSignal = math.Max(c.Config.MinOutput, math.Min(c.Config.MaxOutput, u))
+	c.State.ControlSignal = math.Max(c.Config.MinOutput, math.Min(c.Config.MaxOutput, c.State.UnsaturatedControlSignal))
 	c.State.ControlErrorIntegrand = e + c.Config.AntiWindUpGain*(input.AppliedControlSignal-
 		c.State.UnsaturatedControlSignal)
 	c.State.ControlErrorIntegral = controlErrorIntegral


### PR DESCRIPTION
With faulty inputs, an anti windup controller can accumulate values that reach beyond min/max of a float64, using the inf values in addition or subtraction then creates a NaN.

To prevent the controller to give NaN as ControlSignal output we prevent the controlErrorIntegral reaching inf by clamping it to +/- MaxFloat64.

This gives a more expected behavior and let the user have the possibility to handle the state as the user prefers.