### PR TITLE
fix(anti-windup-controller): clamp error states

### DIFF
--- a/antiwindupcontroller.go
+++ b/antiwindupcontroller.go
@@ -12,8 +12,8 @@ import (
 // Feedback Systems: An Introduction to Scientists and Engineers, 2008
 // (http://www.cds.caltech.edu/~murray/amwiki)
 //
-// The controlErrorIntegral is prevented from reachig +/- inf
-// by clamping the error integral to [-math.MaxFloat64, math.MaxFloat64].
+// The error, error integrand, error integral and error derivative are prevented from reaching +/- inf
+// by clamping them to [-math.MaxFloat64, math.MaxFloat64].
 type AntiWindupController struct {
 	// Config for the AntiWindupController.
 	Config AntiWindupControllerConfig
@@ -78,16 +78,16 @@ func (c *AntiWindupController) Reset() {
 func (c *AntiWindupController) Update(input AntiWindupControllerInput) {
 	e := input.ReferenceSignal - input.ActualSignal
 	controlErrorIntegral := c.State.ControlErrorIntegrand*input.SamplingInterval.Seconds() + c.State.ControlErrorIntegral
-	controlErrorIntegral = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorIntegral))
 	controlErrorDerivative := ((1/c.Config.LowPassTimeConstant.Seconds())*(e-c.State.ControlError) +
 		c.State.ControlErrorDerivative) / (input.SamplingInterval.Seconds()/c.Config.LowPassTimeConstant.Seconds() + 1)
 	c.State.UnsaturatedControlSignal = e*c.Config.ProportionalGain + c.Config.IntegralGain*controlErrorIntegral +
 		c.Config.DerivativeGain*controlErrorDerivative + input.FeedForwardSignal
 	c.State.ControlSignal = math.Max(c.Config.MinOutput, math.Min(c.Config.MaxOutput, c.State.UnsaturatedControlSignal))
 	c.State.ControlErrorIntegrand = e + c.Config.AntiWindUpGain*(c.State.ControlSignal-c.State.UnsaturatedControlSignal)
-	c.State.ControlErrorIntegral = controlErrorIntegral
-	c.State.ControlErrorDerivative = controlErrorDerivative
-	c.State.ControlError = e
+	c.State.ControlErrorIntegrand = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, c.State.ControlErrorIntegrand))
+	c.State.ControlErrorIntegral = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorIntegral))
+	c.State.ControlErrorDerivative = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, controlErrorDerivative))
+	c.State.ControlError = math.Max(-math.MaxFloat64, math.Min(math.MaxFloat64, e))
 }
 
 // DischargeIntegral provides the ability to discharge the controller integral state


### PR DESCRIPTION
Clamp `ControlError`, `ControlErrorIntegrand`, `ControlErrorIntegral` and `ControlErrorDerivative` to `[-math.MaxFloat64, math.MaxFloat64]` to ensure that the controller does not store `Inf` values in states.