### PR TITLE
Ignore NaN and Inf Values in PID controler Inputs

### DIFF
--- a/antiwindupcontroller.go
+++ b/antiwindupcontroller.go
@@ -76,6 +76,12 @@ func (c *AntiWindupController) Reset() {
 
 // Update the controller state.
 func (c *AntiWindupController) Update(input AntiWindupControllerInput) {
+
+	if math.IsNaN(input.ReferenceSignal) || math.IsNaN(input.ActualSignal) ||
+		math.IsInf(input.ReferenceSignal, 0) || math.IsInf(input.ActualSignal, 0) {
+		return
+	}
+
 	e := input.ReferenceSignal - input.ActualSignal
 	controlErrorIntegral := c.State.ControlErrorIntegrand*input.SamplingInterval.Seconds() + c.State.ControlErrorIntegral
 	controlErrorDerivative := ((1/c.Config.LowPassTimeConstant.Seconds())*(e-c.State.ControlError) +

--- a/controller.go
+++ b/controller.go
@@ -1,6 +1,9 @@
 package pid
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // Controller implements a basic PID controller.
 type Controller struct {
@@ -44,6 +47,12 @@ type ControllerInput struct {
 
 // Update the controller state.
 func (c *Controller) Update(input ControllerInput) {
+
+	if math.IsNaN(input.ReferenceSignal) || math.IsNaN(input.ActualSignal) ||
+		math.IsInf(input.ReferenceSignal, 0) || math.IsInf(input.ActualSignal, 0) {
+		return
+	}
+
 	previousError := c.State.ControlError
 	c.State.ControlError = input.ReferenceSignal - input.ActualSignal
 	c.State.ControlErrorDerivative = (c.State.ControlError - previousError) / input.SamplingInterval.Seconds()

--- a/controller_test.go
+++ b/controller_test.go
@@ -72,3 +72,39 @@ func TestSimpleController_Reset(t *testing.T) {
 	// Then
 	assert.Equal(t, expectedController.State, c.State)
 }
+
+func TestNaNInput(t *testing.T) {
+
+	// Given a pidControl with reference value and update interval, dt
+	pidControl := Controller{
+		Config: ControllerConfig{
+			ProportionalGain: 2.0,
+			IntegralGain:     1.0,
+			DerivativeGain:   1.0,
+		},
+		State: ControllerState{
+			ControlError:  11,
+			ControlSignal: 122,
+		},
+	}
+
+	var z float64
+	// Check output value when output value decrease is needed
+	pidControl.Update(ControllerInput{
+		ReferenceSignal:  1 / z,
+		ActualSignal:     2,
+		SamplingInterval: 100 * time.Millisecond,
+	})
+
+	assert.Equal(t, float64(122), pidControl.State.ControlSignal)
+	assert.Equal(t, float64(11), pidControl.State.ControlError)
+
+	pidControl.Update(ControllerInput{
+		ReferenceSignal:  3,
+		ActualSignal:     z / z,
+		SamplingInterval: 100 * time.Millisecond,
+	})
+	assert.Equal(t, float64(122), pidControl.State.ControlSignal)
+	assert.Equal(t, float64(11), pidControl.State.ControlError)
+
+}

--- a/trackingcontroller.go
+++ b/trackingcontroller.go
@@ -80,6 +80,10 @@ func (c *TrackingController) Reset() {
 
 // Update the controller state.
 func (c *TrackingController) Update(input TrackingControllerInput) {
+	if math.IsNaN(input.ReferenceSignal) || math.IsNaN(input.ActualSignal) ||
+		math.IsInf(input.ReferenceSignal, 0) || math.IsInf(input.ActualSignal, 0) {
+		return
+	}
 	e := input.ReferenceSignal - input.ActualSignal
 	controlErrorIntegral := c.State.ControlErrorIntegrand*input.SamplingInterval.Seconds() + c.State.ControlErrorIntegral
 	controlErrorDerivative := ((1/c.Config.LowPassTimeConstant.Seconds())*(e-c.State.ControlError) +


### PR DESCRIPTION
### Description
This merge request introduces checks to handle NaN and Inf values in the ControllerInput struct given in the update function.
If either the ReferenceSignal or ActualSignal contains invalid NaN or Inf values, the update process will safely terminate without affecting the controller's state.
It ensure that invalid inputs do not propagate through the system.

### More question about your module
1. Is there a specific reason why you fill `SamplingInterval` externally instead of calculating it as an internal variable? 
Are you using it with an external time source?
2. I think it might be beneficial to define a Timeout in the controller : If the time since the last update exceeds the Timeout, the controller would skip adding the Integral term. Would you be interested in this? If so, I can create a pr.







