### PR TITLE
ci(dependabot): update dependabot schedule to monthly


### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
 
   - package-ecosystem: gomod
     directory: .sage
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
This PR was scripted to help increase the "signal vs noise" in terms of dependabot PRs.

- Change interval from weekly to monthly (if applicable)
- Remove specific day of week (if applicable)
